### PR TITLE
POM updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,6 @@
 		<url>https://github.com/imagej/ImageJA</url>
 	</scm>
 
-	<repositories>
-		<!-- NB: for project parent -->
-		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-	</repositories>
-
 	<profiles>
 		<profile>
 			<id>javac</id>


### PR DESCRIPTION
This branch purges any use of the ImageJ Maven repository. It switches from our own deployed `com.apple:AppleJavaExtensions:1.5` to an artifact available on Central which serves the same purpose: `com.yuvimasory:orange-extensions:1.3`. See the [OrangeExtensions web site](http://ymasory.github.io/OrangeExtensions/) for details.
