### PR TITLE
Adding close method to CompositeImage

### DIFF
--- a/src/main/java/ij/CompositeImage.java
+++ b/src/main/java/ij/CompositeImage.java
@@ -94,6 +94,34 @@ public class CompositeImage extends ImagePlus {
 			setOpenAsHyperStack(true);
 	}
 
+    public void close() {
+        super.close();
+        rgbPixels = null;
+        imageSource = null;
+        awtImage = null;
+        rgbRaster = null;
+        rgbSampleModel = null;
+        rgbImage = null;
+        rgbCM = null;
+        if (cip != null) {
+            for (int i = 0; i < cip.length; i++) {
+                cip[i] = null;
+            }
+        }
+        
+        if (lut != null) {
+            for (int i = 0; i < lut.length; i++) {
+                lut[i] = null;
+            }
+        }
+        
+        if (channelLuts != null) {
+            for (int i = 0; i < channelLuts.length; i++) {
+                channelLuts[i] = null;
+            }
+        }
+    }
+    
 	public Image getImage() {
 		if (img==null)
 			updateImage();


### PR DESCRIPTION
Setting values in CompositeImage to null to avoid memory leaks when
closing images.

When opening Composite Images via bioformats we have noticed that garbage collection is not fully cleaning up memory which is being held in the CompositeImage object.

Steps to reproduce:
- Load in a composite Tiff image using Bio Formats
- Open the memory manager using Plugins -> Utilities -> Monitor Memory
- Close the Image
- Trigger garbage collection by either clicking in the Image J status bar or Plugins -> Utilities -> Collect Garbage (Fiji only)
- Memory should drop to 15-20 MB, but intact remains much higher

What is occurring:
- When the Image window is closed Fiji retains a reference to the Image but calls the close() function on ImagePlus allowing for processors and arrays to be cleared
- For composite images there is no close so a reference to CompositeImage is held while retaining memory for the image data
- The issue is that class CompositeImage does not contain a close function

Adding a close function and carrying out tests shows that the image memory is freed as expected.
