### PR TITLE
Improve the error when a plugin requires Java 8

### DIFF
--- a/src/main/java/ij/Executer.java
+++ b/src/main/java/ij/Executer.java
@@ -100,6 +100,10 @@ public class Executer implements Runnable {
 						s = e + "\n \nThis plugin requires Java 1.7 or later.";
 						w=700; h=150;
 					}
+					if (s.indexOf("version 52.0")!=-1) {
+						s = e + "\n \nThis plugin requires Java 1.8 or later.";
+						w=700; h=150;
+					}
 				}
 				if (IJ.getInstance()!=null) {
 					s = IJ.getInstance().getInfo()+"\n \n"+s;


### PR DESCRIPTION
@rasband I noticed that the nice error handling for plugins requiring too-new
Java versions did not extend to Java 8. Here is a patch that addresses that.