### PR TITLE
Remove annoying "Exception" window when calling Create Selection from IJ macro

### DIFF
--- a/src/main/java/ij/gui/ShapeRoi.java
+++ b/src/main/java/ij/gui/ShapeRoi.java
@@ -856,6 +856,7 @@ public class ShapeRoi extends Roi {
 	boolean parsePath(PathIterator pIter, double[] params, Vector segments, Vector rois, Vector handles) {
 		boolean result = true;
 		if (pIter==null) return false;
+		if (pIter.isDone()) return false;
 		double pw = 1.0, ph = 1.0;
 		if (imp!=null) {
 			Calibration cal = imp.getCalibration();


### PR DESCRIPTION
Hi guys,

this change resolves an issue when calling "Create Selection" from IJ macro. When you call it on an empty image, an "Exception" window opens but the macro continues. If you have that in a loop, thousands of exception windows open and make FIJI irresponsive. With this change, the behaviour changes just in a way that no longer an exception is thrown. As before, no selection is created. Thus, pre-existing macros should not be affected.

This is a minimal IJ macro example opening the exception window before the change:

newImage("Untitled", "8-bit black", 20, 20, 5);
setAutoThreshold("MaxEntropy dark stack");
run("Create Selection");

Cheers,
Robert