### PR TITLE
Revise default results table extension to .csv or .tsv

### DIFF
--- a/src/main/java/ij/Prefs.java
+++ b/src/main/java/ij/Prefs.java
@@ -662,7 +662,7 @@ public class Prefs {
 	}
 	
 	public static String defaultResultsExtension() {
-		return get("options.ext", ".xls");
+		return get("options.ext", ".csv");
 	}
 		
 }

--- a/src/main/java/ij/Prefs.java
+++ b/src/main/java/ij/Prefs.java
@@ -662,7 +662,7 @@ public class Prefs {
 	}
 	
 	public static String defaultResultsExtension() {
-		return get("options.ext", ".csv");
+		return get("options.ext", ".tsv");
 	}
 		
 }


### PR DESCRIPTION
The results table saves data in a comma separated values text file, which is most commonly associated with the file extension ".csv".  The ".xls" default may have been convenient for easily launching Microsoft Excel at a time when that was a primary tool for data analysis. However, ".xls" is a now deprecated binary format, and does not accurately describe the actual format of the file saved by IJ. The ".csv" file extension is correctly recognized by open source data analysis software such as R, as well as Excel and other proprietary data analysis software.