### PR TITLE
Bugfix-ConvertToRGB/ConvertToGray32

### DIFF
--- a/src/main/java/ij/process/StackConverter.java
+++ b/src/main/java/ij/process/StackConverter.java
@@ -191,7 +191,7 @@ public class StackConverter {
 		}
 		IJ.showProgress(1.0);
 		imp.setStack(null, stack2);
-		imp.setCalibration(imp.getCalibration()); //update calibration
+		imp.setCalibration(cal); //update calibration
 	}
 
 	/** Converts the stack (which must be RGB) to a 

--- a/src/main/java/ij/process/StackConverter.java
+++ b/src/main/java/ij/process/StackConverter.java
@@ -159,7 +159,7 @@ public class StackConverter {
 		}
 		IJ.showProgress(1.0);
 		imp.setStack(null, stack2);
-		imp.setCalibration(imp.getCalibration()); //update calibration
+		imp.setCalibration(cal); //update calibration
 		if (type==ImagePlus.COLOR_RGB) {
 			imp.resetDisplayRange();
 			imp.updateAndDraw();


### PR DESCRIPTION
This is a required bugfix. So far, an ImagePlus that was converted to RGB did loose its calibration. With this fix, it will maintain the calibration.