### PR TITLE
Added check of type of stack before typecast to VirtualStack.

### DIFF
--- a/src/main/java/ij/ImagePlus.java
+++ b/src/main/java/ij/ImagePlus.java
@@ -1562,9 +1562,12 @@ public class ImagePlus implements ImageObserver, Measurements, Cloneable {
 				overlay2 = ip2.getOverlay();
 				if (overlay2!=null)
 					setOverlay(overlay2);
-				Properties props = ((VirtualStack)stack).getProperties();
-				if (props!=null)
-					setProperty("FHT", props.get("FHT"));
+				if(stack instanceof VirtualStack)
+				{
+				    Properties props = ((VirtualStack)stack).getProperties();
+				    if (props!=null)
+				        setProperty("FHT", props.get("FHT"));
+				}
 				pixels = ip2.getPixels();
 			} else
 				pixels = stack.getPixels(currentSlice);


### PR DESCRIPTION
	Some plugins (like my one or netcdf reader) deriving own virtual stacks
implementation directly from ImageStack, so then it is impossible to use
them with ImagePlus. 
	But I am not sure if it's generally good idea to have ImagePlus
dependent on VirtualStack.