### PR TITLE
Fix scroll wheel zoom in image stacks

### DIFF
--- a/src/main/java/ij/gui/StackWindow.java
+++ b/src/main/java/ij/gui/StackWindow.java
@@ -162,12 +162,13 @@ public class StackWindow extends ImageWindow implements Runnable, AdjustmentList
 			int rotation = e.getWheelRotation();
 			boolean ctrl = (e.getModifiers()&Event.CTRL_MASK)!=0;
 			if ((ctrl||IJ.shiftKeyDown()) && ic!=null) {
-				int ox = ic.offScreenX(e.getX());
-				int oy = ic.offScreenY(e.getX());
+				Point loc = ic.getCursorLoc();
+				int x = ic.screenX(loc.x);
+				int y = ic.screenY(loc.y);
 				if (rotation<0)
-					ic.zoomIn(ox,oy);
+					ic.zoomIn(x, y);
 				else
-					ic.zoomOut(ox,oy);
+					ic.zoomOut(x, y);
 				return;
 			}
 			if (hyperStack) {


### PR DESCRIPTION
When zooming in image stacks (i.e. StackWindow instances), zooming with "+" and "-" keyboard shortcuts zooms in on the pixel the cursor is hovering over, as indented. However, before this fix, zooming with CTRL or SHIFT + mouse wheel only zoomed in on a fixed location. It is worth mentioning that on non-stacked images (ImageWindow instances), this was not an issue, so I just took the code from there.

This would also close the following open issue: [https://github.com/imagej/imagej/issues/139](https://github.com/imagej/imagej/issues/139)