### PR TITLE
added 1024x1024x2 size to tiff file buffer

### DIFF
--- a/src/main/java/ij/io/FileSaver.java
+++ b/src/main/java/ij/io/FileSaver.java
@@ -205,7 +205,7 @@ public class FileSaver {
 		DataOutputStream out = null;
 		try {
 			TiffEncoder file = new TiffEncoder(fi);
-			out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)));
+			out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path), 1024*1024*2));
 			file.write(out);
 			out.close();
 		} catch (IOException e) {


### PR DESCRIPTION
Saving large tiff files to a network location is very slow (especially using windows). Adding a large buffer size to the FIleOutputStream constructor makes it much faster.