### PR TITLE
Add group attribute for ROI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings
 target
+bin

--- a/src/main/java/ij/gui/Roi.java
+++ b/src/main/java/ij/gui/Roi.java
@@ -4,6 +4,7 @@ import ij.process.*;
 import ij.measure.*;
 import ij.plugin.frame.Recorder;
 import ij.plugin.filter.Analyzer;
+import ij.plugin.LutLoader;
 import ij.plugin.filter.ThresholdToSelection;
 import ij.plugin.RectToolOptions;
 import ij.macro.Interpreter;
@@ -11,9 +12,12 @@ import ij.io.RoiDecoder;
 import java.awt.*;
 import java.util.*;
 import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.awt.image.*;
 import java.awt.event.*;
 import java.awt.geom.*;
+import java.awt.Color;
 
 /** 
  * A rectangular region of interest and superclass for the other ROI classes. 
@@ -2174,7 +2178,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		currentGroup = group;
 	}
 	
-	/** Return group of this ROI **/
+	/** Return group attribute of this ROI **/
 	public int getGroup() {
 		return this.group;
 	}
@@ -2182,6 +2186,18 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	/** Set the group of the Roi **/
 	public void setGroup(int group) {
 		this.group = group;
+	}
+	
+	/** Retrieve color associated to the roi group **/
+	public static Color getGroupColor(int group) {
+		Color color = Color.YELLOW; // default yellow for 0 and negative
+		
+		if (group>0) { // other group: read Glasbey Lut
+			Path lutPath = Paths.get(IJ.getDirectory("luts"), "Glasbey.lut");
+			LUT lut = LutLoader.openLut( lutPath.toString() );
+			color =  Color( lut.getRGB(group) );
+		}
+		return color;
 	}
 	
 	/** Overridden by PolygonRoi (angle between first two points), TextRoi (text angle) and Line (line angle). */

--- a/src/main/java/ij/gui/Roi.java
+++ b/src/main/java/ij/gui/Roi.java
@@ -40,7 +40,6 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	static final int NO_MODS=0, ADD_TO_ROI=1, SUBTRACT_FROM_ROI=2; // modification states
 		
 	int startX, startY, x, y, width, height;
-	int currentGroup = 1; // class variable ? Static ? will be changed for each roi but 1 (or 0) should be used as default
 
 	double startXD, startYD;
 	Rectangle2D.Double bounds;
@@ -56,7 +55,9 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	protected static int pasteMode = Blitter.COPY;
 	protected static int lineWidth = 1;
 	protected static Color defaultFillColor;
+	protected static int currentGroup = 0; 
 	private static Vector listeners = new Vector();
+
 		
 	protected int type;
 	protected int xMax, yMax;
@@ -2161,10 +2162,24 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 			return height;
 	}
 	
+	
+	/** Get current group value assigned to newly created ROI **/
+	public static int getCurrentGroup() {
+		return currentGroup;
+	}
+	
+	
+	/** Set group value assigned to newly created ROI **/
+	public static void setCurrentGroup(int group) {
+		currentGroup = group;
+	}
+	
+	/** Return group of this ROI **/
 	public int getGroup() {
 		return this.group;
 	}
 	
+	/** Set the group of the Roi **/
 	public void setGroup(int group) {
 		this.group = group;
 	}

--- a/src/main/java/ij/gui/Roi.java
+++ b/src/main/java/ij/gui/Roi.java
@@ -40,6 +40,8 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	static final int NO_MODS=0, ADD_TO_ROI=1, SUBTRACT_FROM_ROI=2; // modification states
 		
 	int startX, startY, x, y, width, height;
+	int currentGroup = 1; // class variable ? Static ? will be changed for each roi but 1 (or 0) should be used as default
+
 	double startXD, startYD;
 	Rectangle2D.Double bounds;
 	int activeHandle;
@@ -55,7 +57,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	protected static int lineWidth = 1;
 	protected static Color defaultFillColor;
 	private static Vector listeners = new Vector();
-	
+		
 	protected int type;
 	protected int xMax, yMax;
 	protected ImagePlus imp;
@@ -95,6 +97,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	private double ycenter;
 	private boolean listenersNotified;
 	private boolean antiAlias = true;
+	private int group;
 
 
 	/** Creates a rectangular ROI. */
@@ -117,6 +120,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		this.cornerDiameter = cornerDiameter;
 		this.x = x;
 		this.y = y;
+		this.group = currentGroup; //initialize with current selected Group
 		startX = x; startY = y;
 		oldX = x; oldY = y; oldWidth=0; oldHeight=0;
 		this.width = width;
@@ -166,6 +170,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		}
 		setLocation(ox, oy);
 		this.cornerDiameter = cornerDiameter;
+		this.group = currentGroup;
 		width = 0;
 		height = 0;
 		state = CONSTRUCTING;
@@ -2154,6 +2159,14 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 			return bounds.height;
 		else
 			return height;
+	}
+	
+	public int getGroup() {
+		return this.group;
+	}
+	
+	public void setGroup(int group) {
+		this.group = group;
 	}
 	
 	/** Overridden by PolygonRoi (angle between first two points), TextRoi (text angle) and Line (line angle). */

--- a/src/main/java/ij/gui/Roi.java
+++ b/src/main/java/ij/gui/Roi.java
@@ -55,7 +55,8 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	
 	public static Roi previousRoi;  //for Edit>Selection>Restore Selection
 	public static final BasicStroke onePixelWide = new BasicStroke(1);
-	protected static Color ROIColor = Prefs.getColor(Prefs.ROICOLOR,Color.yellow);
+	//protected static Color ROIColor = Prefs.getColor(Prefs.ROICOLOR,Color.yellow);
+	protected static Color ROIColor = Color.yellow; // contains the current group color. As long as the currentGroup is not stored in prefs, initilaised color=yellow and group=0
 	protected static int pasteMode = Blitter.COPY;
 	protected static int lineWidth = 1;
 	protected static Color defaultFillColor;
@@ -125,7 +126,8 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		this.cornerDiameter = cornerDiameter;
 		this.x = x;
 		this.y = y;
-		this.group = currentGroup; //initialize with current selected Group
+		this.group = currentGroup; //initialize with current selected Group and associated color
+		this.strokeColor = ROIColor;
 		startX = x; startY = y;
 		oldX = x; oldY = y; oldWidth=0; oldHeight=0;
 		this.width = width;
@@ -176,6 +178,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		setLocation(ox, oy);
 		this.cornerDiameter = cornerDiameter;
 		this.group = currentGroup;
+		this.strokeColor = ROIColor;
 		width = 0;
 		height = 0;
 		state = CONSTRUCTING;
@@ -2173,9 +2176,11 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	}
 	
 	
-	/** Set group value assigned to newly created ROI **/
+	/** Set group value assigned to newly created ROI, and update default ROI color accordingly **/
 	public static void setCurrentGroup(int group) {
 		currentGroup = group;
+		Color color = getGroupColor(group);
+		setColor(color); //update the default Roi Color to the new group
 	}
 	
 	/** Return group attribute of this ROI **/
@@ -2183,19 +2188,26 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		return this.group;
 	}
 	
-	/** Set the group of the Roi **/
+	/** Set the group of the Roi, and update stroke color accordingly **/
 	public void setGroup(int group) {
 		this.group = group;
+		Color color = getGroupColor(group);
+		this.strokeColor = color;
+		notifyListeners(RoiListener.MODIFIED);
+		
+		if (imp!=null) { // Update Roi Color in the GUI
+			imp.draw();
+		}
 	}
 	
-	/** Retrieve color associated to the roi group **/
-	public static Color getGroupColor(int group) {
+	/** Retrieve color associated to a given roi group **/
+	private static Color getGroupColor(int group) {
 		Color color = Color.YELLOW; // default yellow for 0 and negative
 		
 		if (group>0) { // other group: read Glasbey Lut
 			Path lutPath = Paths.get(IJ.getDirectory("luts"), "Glasbey.lut");
 			LUT lut = LutLoader.openLut( lutPath.toString() );
-			color =  Color( lut.getRGB(group) );
+			color =  new Color( lut.getRGB(group) );
 		}
 		return color;
 	}

--- a/src/main/java/ij/gui/RoiProperties.java
+++ b/src/main/java/ij/gui/RoiProperties.java
@@ -189,9 +189,7 @@ public class RoiProperties {
 			justification = gd.getNextChoiceIndex();
 		}
 		
-		int newGroup = (int)gd.getNextNumber();
-		group = (newGroup>=0) ? newGroup : group; // update roi group only if a positive value is entered 
-		roi.setGroup(group);
+		roi.setGroup((int)gd.getNextNumber());
 		
 		if (!isLine) {
 			if (isPoint) {
@@ -260,7 +258,7 @@ public class RoiProperties {
 				rois[i].setStrokeColor(strokeColor);
 				rois[i].setStrokeWidth((float)strokeWidth);
 				rois[i].setFillColor(fillColor);
-				rois[i].setGroup(group); // test ?
+				rois[i].setGroup(group);
 			}
 			imp.draw();
 			imp.getProcessor(); // needed for correct recordering

--- a/src/main/java/ij/gui/RoiProperties.java
+++ b/src/main/java/ij/gui/RoiProperties.java
@@ -166,6 +166,10 @@ public class RoiProperties {
 				gd.addMessage("No properties");
 			}
 		}
+		// Roi group
+		int group = roi.getGroup(); //What happened if several rois selected and from different group ?
+		gd.addNumericField("Group", group);
+		
 		if (showName && "".equals(name) && "none".equals(position) && "none".equals(fillc))
 			gd.setSmartRecording(true);
 		gd.showDialog();
@@ -184,6 +188,11 @@ public class RoiProperties {
 			angle = gd.getNextNumber();
 			justification = gd.getNextChoiceIndex();
 		}
+		
+		int newGroup = (int)gd.getNextNumber();
+		group = (newGroup>=0) ? newGroup : group; // update roi group only if a positive value is entered 
+		roi.setGroup(group); // No effect
+		
 		if (!isLine) {
 			if (isPoint) {
 				int index = gd.getNextChoiceIndex();
@@ -251,6 +260,7 @@ public class RoiProperties {
 				rois[i].setStrokeColor(strokeColor);
 				rois[i].setStrokeWidth((float)strokeWidth);
 				rois[i].setFillColor(fillColor);
+				rois[i].setGroup(group); // test ?
 			}
 			imp.draw();
 			imp.getProcessor(); // needed for corect recordering

--- a/src/main/java/ij/gui/RoiProperties.java
+++ b/src/main/java/ij/gui/RoiProperties.java
@@ -191,7 +191,7 @@ public class RoiProperties {
 		
 		int newGroup = (int)gd.getNextNumber();
 		group = (newGroup>=0) ? newGroup : group; // update roi group only if a positive value is entered 
-		roi.setGroup(group); // No effect
+		roi.setGroup(group);
 		
 		if (!isLine) {
 			if (isPoint) {
@@ -263,7 +263,7 @@ public class RoiProperties {
 				rois[i].setGroup(group); // test ?
 			}
 			imp.draw();
-			imp.getProcessor(); // needed for corect recordering
+			imp.getProcessor(); // needed for correct recordering
 		}
 		if (listCoordinates) {
 			if (showPointCounts && (roi instanceof PointRoi))

--- a/src/main/java/ij/gui/Toolbar.java
+++ b/src/main/java/ij/gui/Toolbar.java
@@ -1820,6 +1820,8 @@ public class Toolbar extends Canvas implements MouseListener, MouseMotionListene
 			installMacroFromJar("/macros/LUTMenuTool.txt");
 		else if (label.startsWith("Command Finder"))
 			installMacroFromJar("/macros/CommandFinderTool.txt");
+		else if (label.startsWith("Group"))
+			installMacroFromJar("/macros/GroupMenuTool.txt");
 		else
 			ok = false;
 		return ok;

--- a/src/main/java/ij/macro/Functions.java
+++ b/src/main/java/ij/macro/Functions.java
@@ -7284,8 +7284,7 @@ public class Functions implements MacroConstants, Measurements {
 		} else if (name.equals("getCurrentGroup")) {
 			interp.getParens();
 			return new Variable(Roi.getCurrentGroup());
-		} else if (name.equals("setCurrentGroup")) { // Does not work ?
-			interp.getParens();
+		} else if (name.equals("setCurrentGroup")) {
 			Roi.setCurrentGroup((int)getArg());
 			return null;
 		} else if (name.equals("getProperty")) {

--- a/src/main/java/ij/macro/Functions.java
+++ b/src/main/java/ij/macro/Functions.java
@@ -7275,6 +7275,19 @@ public class Functions implements MacroConstants, Measurements {
 			interp.getParens();
 			String roiName = roi.getName();
 			return new Variable(roiName!=null?roiName:"");
+		} else if (name.equals("getGroup")) {
+			interp.getParens(); // not sure this is needed
+			return new Variable(roi.getGroup());
+		} else if (name.equals("setGroup")) {
+			roi.setGroup((int)getArg());
+			return null;
+		} else if (name.equals("getCurrentGroup")) {
+			interp.getParens();
+			return new Variable(Roi.getCurrentGroup());
+		} else if (name.equals("setCurrentGroup")) { // Does not work ?
+			interp.getParens();
+			Roi.setCurrentGroup((int)getArg());
+			return null;
 		} else if (name.equals("getProperty")) {
 			String property = roi.getProperty(getStringArg());
 			return new Variable(property!=null?property:"");

--- a/src/main/java/ij/plugin/Options.java
+++ b/src/main/java/ij/plugin/Options.java
@@ -24,6 +24,9 @@ public class Options implements PlugIn {
 			{dicom(); return;}
 		else if (arg.equals("reset"))
 			{reset(); return;}
+		else if (arg.equals("roiGroup"))
+			{roiGroup(); return;}
+			
 	}
 				
 	// Miscellaneous Options
@@ -197,6 +200,15 @@ public class Options implements PlugIn {
 	private void reset() {
 		if (IJ.showMessageWithCancel("Reset Preferences", "Preferences will be reset when ImageJ restarts."))
 			Prefs.resetPreferences();
+	}
+	
+	void roiGroup() {
+		GenericDialog gd = new GenericDialog("ROI Group Options");
+		gd.addNumericField("Current group", Roi.getCurrentGroup());
+		gd.showDialog();
+		if (gd.wasCanceled())
+			return;
+		Roi.setCurrentGroup( (int)gd.getNextNumber() );
 	}
 
 } // class Options

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -2305,6 +2305,26 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 			roi.update(shiftKeyDown, altKeyDown);
 		}
 	}
+	
+	/** Select Roi of a given group */
+	public void selectGroup(int group) {
+		ArrayList<Integer> listSelected = new ArrayList<Integer>();
+		for (int i=0; i<getCount(); i++) {
+			Roi roi = getRoi(i);
+			if (roi.getGroup() == group) {
+				listSelected.add(i);
+			}
+		}
+		// Convert listArray to int[] (no simpler solution ?)
+		int[] arraySelected = new int[listSelected.size()];
+		for (int j=0; j<listSelected.size(); j++) {
+			arraySelected[j]=listSelected.get(j);
+		}
+		//Integer[] arraySelected = (Integer[]) listSelected.toArray(new Integer[listSelected.size()]);
+		//int [] ints = listSelected.stream().mapToInt(Integer::intValue).toArray();
+		//int[] array = listSelected.stream().mapToInt(i->i).toArray();
+		setSelectedIndexes(arraySelected);
+	}
 
 	public void deselect() {
 		int n = getCount();

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1339,6 +1339,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		double opacity = -1;
 		int pointType = -1;
 		int pointSize = -1;
+		int group = -1;
 		if (showDialog) {
 			//String label = (String) listModel.getElementAt(indexes[0]);
 			rpRoi = (Roi)rois.get(indexes[0]);
@@ -1355,10 +1356,13 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 			RoiProperties rp = new RoiProperties("Properties", rpRoi);
 			if (!rp.showDialog())
 				return;
+			
+			// Recover parameters of the Property window that were stored in the "transient" roi
 			lineWidth = (int)rpRoi.getStrokeWidth();
 			defaultLineWidth = lineWidth;
 			color =	 rpRoi.getStrokeColor();
 			fillColor =	 rpRoi.getFillColor();
+			group = rpRoi.getGroup();
 			defaultColor = color;
 			if (rpRoi instanceof TextRoi) {
 				font = ((TextRoi)rpRoi).getCurrentFont();
@@ -1384,6 +1388,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 			if (color!=null) roi.setStrokeColor(color);
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			roi.setFillColor(fillColor);
+			roi.setGroup(group);
 			if (rpRoi!=null && n==1) {
 				if (rpRoi.hasHyperStackPosition())
 					roi.setPosition(rpRoi.getCPosition(), rpRoi.getZPosition(), rpRoi.getTPosition());
@@ -1410,6 +1415,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		Roi roi = imp!=null?imp.getRoi():null;
 		boolean showingAll = ic!=null &&  ic.getShowAllROIs();
 		if (roi!=null && (n==1||!showingAll)) {
+			roi.setGroup(group);
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			if (color!=null) roi.setStrokeColor(color);
 			if (fillColor!=null) roi.setFillColor(fillColor);

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1326,7 +1326,16 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		imp.unlock();
 		return true;
 	}
-
+	
+	/** Set Group for the ROI selected in the RoiManager**/ 
+	public void setGroupForSelectedRoi(int group) {
+		int[] indexes = getSelectedIndexes();
+		for(int i: indexes) {
+			Roi roi = getRoi(i);
+			roi.setGroup(group);
+		}
+		return;
+	}
 	void setProperties(Color color, int lineWidth, Color fillColor) {
 		boolean showDialog = color==null && lineWidth==-1 && fillColor==null;
 		int[] indexes = getIndexes();

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1336,6 +1336,20 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		}
 		return;
 	}
+	
+	/** Macro-callable version of setGroupForSelectedRoi **/
+	public static void setGroupForSelectedRoi(String group) {
+		RoiManager rm = getInstance();
+		try {
+			int groupInt = Integer.parseInt(group);
+			if (groupInt>=0) rm.setGroupForSelectedRoi(groupInt);
+		}
+		catch (NumberFormatException e){
+			return;
+			}
+	}
+	
+	
 	void setProperties(Color color, int lineWidth, Color fillColor) {
 		boolean showDialog = color==null && lineWidth==-1 && fillColor==null;
 		int[] indexes = getIndexes();
@@ -2306,7 +2320,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		}
 	}
 	
-	/** Select Roi of a given group */
+	/** Select all Rois in RoiManager of a given group */
 	public void selectGroup(int group) {
 		ArrayList<Integer> listSelected = new ArrayList<Integer>();
 		for (int i=0; i<getCount(); i++) {
@@ -2324,6 +2338,19 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		//int [] ints = listSelected.stream().mapToInt(Integer::intValue).toArray();
 		//int[] array = listSelected.stream().mapToInt(i->i).toArray();
 		setSelectedIndexes(arraySelected);
+	}
+	
+	/** Macro-callable version of selectGroup */
+	public static void selectGroup(String group) {
+		RoiManager rm = getInstance();
+		try {
+			int groupInt = Integer.parseInt(group);
+			if (groupInt>=0) rm.selectGroup(groupInt);
+		}
+		catch (NumberFormatException e){
+			return;
+			}
+		
 	}
 
 	public void deselect() {

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1411,7 +1411,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 			if (color!=null) roi.setStrokeColor(color);
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			roi.setFillColor(fillColor);
-			roi.setGroup(group); // currently set the StrokeColor too
+			roi.setGroup(group); // overwrite the strokeColor for group>=0
 			if (rpRoi!=null && n==1) {
 				if (rpRoi.hasHyperStackPosition())
 					roi.setPosition(rpRoi.getCPosition(), rpRoi.getZPosition(), rpRoi.getTPosition());
@@ -1440,7 +1440,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		if (roi!=null && (n==1||!showingAll)) {
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			if (color!=null) roi.setStrokeColor(color);
-			roi.setGroup(group); //currently replace the color
+			roi.setGroup(group); // replace the StrokeColor for group>=0
 			if (fillColor!=null) roi.setFillColor(fillColor);
 			if (roi!=null && (roi instanceof TextRoi)) {
 				((TextRoi)roi).setCurrentFont(font);

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1388,7 +1388,7 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 			if (color!=null) roi.setStrokeColor(color);
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			roi.setFillColor(fillColor);
-			roi.setGroup(group);
+			roi.setGroup(group); // currently set the StrokeColor too
 			if (rpRoi!=null && n==1) {
 				if (rpRoi.hasHyperStackPosition())
 					roi.setPosition(rpRoi.getCPosition(), rpRoi.getZPosition(), rpRoi.getTPosition());
@@ -1415,9 +1415,9 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		Roi roi = imp!=null?imp.getRoi():null;
 		boolean showingAll = ic!=null &&  ic.getShowAllROIs();
 		if (roi!=null && (n==1||!showingAll)) {
-			roi.setGroup(group);
 			if (lineWidth>=0) roi.setStrokeWidth(lineWidth);
 			if (color!=null) roi.setStrokeColor(color);
+			roi.setGroup(group); //currently replace the color
 			if (fillColor!=null) roi.setFillColor(fillColor);
 			if (roi!=null && (roi instanceof TextRoi)) {
 				((TextRoi)roi).setCurrentFont(font);

--- a/src/main/resources/IJ_Props.txt
+++ b/src/main/resources/IJ_Props.txt
@@ -111,7 +111,7 @@ options14="Compiler...",ij.plugin.Compiler("options")
 options15="DICOM...",ij.plugin.Options("dicom")
 options16="Startup...",ij.plugin.Startup
 options17="Misc...",ij.plugin.Options("misc")
-options18=-
+options18="ROI group...", ij.plugin.Options("roiGroup")
 options19="Reset... ",ij.plugin.Options("reset")
 
 # Plugins installed in the Image/Adjust submenu

--- a/src/main/resources/macros/GroupMenuTool.txt
+++ b/src/main/resources/macros/GroupMenuTool.txt
@@ -1,8 +1,43 @@
    var rCmds = newMenu("Group Menu Tool", 
-                        newArray("Set current Roi Group", "Set selected Roi Group") );
+                        newArray("Set current Roi Group", "Set Group for selected Roi", "Select Group") );
       
    macro "Group Menu Tool - C037T1d16R" {
        cmd = getArgument();
        if (cmd=="Set current Roi Group")
 		   run("ROI group...");
+		   
+	   else if (cmd=="Set Group for selected Roi")
+	   		setGroup();		   
+		 
+		else if (cmd=="Select Group")
+			selectGroup();
+
+		else
+			return;
    }
+
+
+function setGroup(){
+   
+   // Ask group to set
+   Dialog.create("Set group");
+   Dialog.addString("Group", "0");
+   Dialog.show;
+   
+   // recover group and call static method
+   group = Dialog.getString();
+   call("ij.plugin.frame.RoiManager.setGroupForSelectedRoi", group);
+   }
+
+
+function selectGroup(){
+	
+	// Ask group to select
+	Dialog.create("Select group");
+    Dialog.addString("Group", "0");
+    Dialog.show;
+    
+   // recover group and call static method
+   group = Dialog.getString();
+   call("ij.plugin.frame.RoiManager.selectGroup", group);
+}

--- a/src/main/resources/macros/GroupMenuTool.txt
+++ b/src/main/resources/macros/GroupMenuTool.txt
@@ -1,0 +1,8 @@
+   var rCmds = newMenu("Group Menu Tool", 
+                        newArray("Set current Roi Group", "Set selected Roi Group") );
+      
+   macro "Group Menu Tool - C037T1d16R" {
+       cmd = getArgument();
+       if (cmd=="Set current Roi Group")
+		   run("ROI group...");
+   }

--- a/src/main/resources/macros/StartupMacros.txt
+++ b/src/main/resources/macros/StartupMacros.txt
@@ -5,4 +5,4 @@
   macro "Brush Built-in Tool" {}
   macro "Flood Filler Built-in Tool" {}
   macro "Arrow Built-in Tool" {}
-
+  macro "Group Menu Built-in Tool" {}


### PR DESCRIPTION
This PR adds a group integer attribute to ROI instances, such that ROI can be used to annotate different cell types, categories of objects...

ROI of the same group have the same color (for positive groups, negative groups keep the default color)

Current group for newly drawn ROI or existing ROI can be set via the Menu or ROI Manager

The PR is not finalized (macro recording, saving the group with the ROI still to do) 