### PR TITLE
Enabling restore selection after convex hull

### DIFF
--- a/src/main/java/ij/plugin/Selection.java
+++ b/src/main/java/ij/plugin/Selection.java
@@ -499,6 +499,7 @@ public class Selection implements PlugIn, Measurements {
 		FloatPolygon p = roi.getFloatConvexHull();
 		if (p!=null) {
 			Undo.setup(Undo.ROI, imp);
+			imp.deleteRoi();
 			Roi roi2 = new PolygonRoi(p, roi.POLYGON);
 			transferProperties(roi, roi2);
 			imp.setRoi(roi2);


### PR DESCRIPTION
Hi everyone!

This small PR fixes a bug by which restoring the selection after running `Convex Hull` did not bring the last selection, but the second last instead (or did nothing if the original selection was the first one in the list).

A call to `imp.deleteRoi()`  was missing (as is done for` fitCircle()`,` createEllipse()`, `toBoundingBox()`, etc).