### PR TITLE
fixed bug when opening empty .xml 

### DIFF
--- a/src/main/java/ij/measure/ResultsTable.java
+++ b/src/main/java/ij/measure/ResultsTable.java
@@ -1085,7 +1085,7 @@ public class ResultsTable implements Cloneable {
 		}
 		String commaSubstitute2 = ""+commaSubstitute;
 		String[] lines = text.split(lineSeparator);
-		if (lines.length==0)
+		if (lines.length==0 || (lines.length==1 && lines[0].length()==0))
 			throw new IOException("Table is empty or invalid");
 		String[] headings = lines[0].split(cellSeparator);
 		if (headings.length<1)


### PR DESCRIPTION
Hi!

This PR fixes a bug by which an empty .xml table was successfully opened, but misbehaved when setting values afterwards. An error should have been raised when trying to open an empty file.

There was an issue when checking for an empty file: if the file is empty, splitting the contents always renders a single-element array containing an empty string, not an empty array, which was the condition screened for.

This issue was reported and discussed in this topic: https://forum.image.sc/t/imagejs-setresult-inserts-result-into-wrong-column-after-loading-results-from-text-file/34509

Thanks!