### PR TITLE
Add "Roi" entry to Edit>Options

### DIFF
--- a/src/main/java/ij/plugin/Options.java
+++ b/src/main/java/ij/plugin/Options.java
@@ -16,6 +16,8 @@ public class Options implements PlugIn {
 			{miscOptions(); return;}
 		else if (arg.equals("line"))
 			{lineWidth(); return;}
+		else if (arg.equals("roi"))
+			{roi(); return;}
 		else if (arg.equals("io"))
 			{io(); return;}
 		else if (arg.equals("conv"))
@@ -95,6 +97,22 @@ public class Options implements PlugIn {
             if (roi!=null && roi.isLine()) imp.draw();
 		}
 	}
+	
+	// Roi options
+	void roi() {
+		GenericDialog gd = new GenericDialog("Roi Options");
+		gd.addNumericField("Default stroke width", Roi.getDefaultStrokeWidth(), 1);
+		gd.addNumericField("Default group", Roi.getDefaultGroup(), 0);		
+		gd.showDialog();
+		if (gd.wasCanceled())
+			return;
+		
+		// Update values if OKed
+		Roi.setDefaultStrokeWidth( gd.getNextNumber() );
+		Roi.setDefaultGroup( (int)gd.getNextNumber() );
+	}
+	
+	
 
 	// Input/Output options
 	void io() {

--- a/src/main/resources/IJ_Props.txt
+++ b/src/main/resources/IJ_Props.txt
@@ -112,8 +112,9 @@ options14="Compiler...",ij.plugin.Compiler("options")
 options15="DICOM...",ij.plugin.Options("dicom")
 options16="Startup...",ij.plugin.Startup
 options17="Misc...",ij.plugin.Options("misc")
-options18=-
-options19="Reset... ",ij.plugin.Options("reset")
+options18="Roi...",ij.plugin.Options("roi")
+options19=-
+options20="Reset... ",ij.plugin.Options("reset")
 
 # Plugins installed in the Image/Adjust submenu
 adjust01="Brightness/Contrast...[C]",ij.plugin.frame.ContrastAdjuster


### PR DESCRIPTION
This PR adds a new `Roi...` entry to `Edit>Options`, which allow to see most roi-related options in one place.

I did not add the fill color, as I could not think of a clever way to convert from any `Color` instance to a string representation that would be intuitive to users (eventhough the opposite is straightforward for some well defined colors ex: "black"...). 
I guess the best would be to have a palette like the one from the color picker but I have no idea how to put that into a generic dialog.
I think a majority of people have `FillColor=None` anyway, and no one seems to complain about it so I think it's fine to skip this option.