### PR TITLE
Multiple rois cropping methods

### DIFF
--- a/src/main/java/ij/ImagePlus.java
+++ b/src/main/java/ij/ImagePlus.java
@@ -2452,6 +2452,13 @@ public class ImagePlus implements ImageObserver, Measurements, Cloneable {
 		}
 		return cropImps;
 	}
+	
+	/** Multi-roi cropping with default "slice" option
+	 * @see #crop
+	 */
+	public ImagePlus[] crop(Roi[] rois) {
+		return this.crop(rois, "slice");
+	}
 
 	/** Returns a new ImagePlus with this image's attributes
 		(e.g. spatial scale), but no image. */

--- a/src/main/java/ij/ImagePlus.java
+++ b/src/main/java/ij/ImagePlus.java
@@ -2428,6 +2428,30 @@ public class ImagePlus implements ImageObserver, Measurements, Cloneable {
 			return new Duplicator().run(this, (int)s1, (int)s2);
 		}
 	}
+	
+	/** Returns an array of cropped ImagePlus according to the provided list of rois. 
+	 * 'options' applies if the ImagePlus is a stack and can be "stack", "slice" or a range (e.g., "20-30").
+	 * @see #crop
+	 * @see ij.plugin.Duplicator#crop
+	*/
+	public ImagePlus[] crop(Roi[] rois, String options) {
+		int nRois = rois.length; 
+		ImagePlus[] cropImps = new ImagePlus[nRois];
+		
+		for (int i=0; i<nRois; i++) {
+			Roi cropRoi = rois[i];
+			String name = cropRoi.getName();
+			if (options.equals("slice") && this.getStackSize()>1) {
+				int position = cropRoi.getPosition();
+				this.setSlice(position); // no effect if roi position is undefined (=0), ok
+			}
+			this.setRoi(cropRoi);
+			ImagePlus cropped = this.crop(options);
+			cropped.setTitle(name);
+			cropImps[i] = cropped;
+		}
+		return cropImps;
+	}
 
 	/** Returns a new ImagePlus with this image's attributes
 		(e.g. spatial scale), but no image. */

--- a/src/main/java/ij/macro/Functions.java
+++ b/src/main/java/ij/macro/Functions.java
@@ -7737,6 +7737,7 @@ public class Functions implements MacroConstants, Measurements {
 					String title   = cropImp.getTitle(); 
 					String outPath = outDir + "/" + title; 
 					IJ.saveAs(cropImp, extension, outPath); //extension, outPath
+					IJ.showStatus("Saved cropped images in " + outDir);
 				}
 				
 			}

--- a/src/main/java/ij/macro/Functions.java
+++ b/src/main/java/ij/macro/Functions.java
@@ -7724,6 +7724,23 @@ public class Functions implements MacroConstants, Measurements {
 		} else if (name.equals("selectGroup")) {
 			rm.selectGroup((int)getArg());
 			return null;
+		} else if (name.equals("multiCrop")) {
+			ImagePlus imp = getImage();
+			ImagePlus[] crops = rm.multiCrop(imp, getFirstString());
+			String output    = getNextString();
+			String outDir    = getNextString();
+			String extension = getLastString();
+			for (ImagePlus cropImp:crops) {
+				if (output.equals("show") || output.equals("both")) cropImp.show();
+				
+				if (output.equals("save") || output.equals("both")) {
+					String title   = cropImp.getTitle(); 
+					String outPath = outDir + "/" + title; 
+					IJ.saveAs(cropImp, extension, outPath); //extension, outPath
+				}
+				
+			}
+			return null;
 		} else
 			interp.error("Unrecognized RoiManager function");
 		return null;

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1203,11 +1203,19 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 	/** This method allows to crop an ImagePlus once for each roi of the RoiManager.
 	 * if some rois are selected, only those are used for cropping, otherwise all rois 
 	 * of the RoiManager are used for cropping.
+	 * Options is either "slice", "stack" or a range of slices as in imp.crop(options)
      */
 	public ImagePlus[] multiCrop(ImagePlus imp, String options) {
 		Roi[] rois = getSelectedRoisAsArray();
 		return imp.crop(rois, options);
 	}
+	
+	public ImagePlus[] multiCrop(ImagePlus imp) {
+		Roi[] rois = getSelectedRoisAsArray();
+		return imp.crop(rois);
+	}
+	
+	
 
 	int getColumnCount(ImagePlus imp, int measurements) {
 		ImageStatistics stats = imp.getStatistics(measurements);

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1200,19 +1200,13 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		return rtMulti;
 	}
 	
-	public static ImagePlus[] multiCrop(ImagePlus imp, Roi[] rois, String stackMode) {
-		int nRois = rois.length; 
-		ImagePlus[] cropImps = new ImagePlus[nRois];
-		
-		for (int i=0; i<nRois; i++) {
-			Roi cropRoi = rois[i];
-			String name = cropRoi.getName();
-			imp.setRoi(cropRoi);
-			ImagePlus cropped = imp.crop(stackMode);
-			cropped.setTitle(name);
-			cropImps[i] = cropped;
-		}
-		return cropImps;
+	/** This method allows to crop an ImagePlus once for each roi of the RoiManager.
+	 * if some rois are selected, only those are used for cropping, otherwise all rois 
+	 * of the RoiManager are used for cropping.
+     */
+	public ImagePlus[] multiCrop(ImagePlus imp, String options) {
+		Roi[] rois = getSelectedRoisAsArray();
+		return imp.crop(rois, options);
 	}
 
 	int getColumnCount(ImagePlus imp, int measurements) {

--- a/src/main/java/ij/plugin/frame/RoiManager.java
+++ b/src/main/java/ij/plugin/frame/RoiManager.java
@@ -1199,6 +1199,21 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 		}
 		return rtMulti;
 	}
+	
+	public static ImagePlus[] multiCrop(ImagePlus imp, Roi[] rois, String stackMode) {
+		int nRois = rois.length; 
+		ImagePlus[] cropImps = new ImagePlus[nRois];
+		
+		for (int i=0; i<nRois; i++) {
+			Roi cropRoi = rois[i];
+			String name = cropRoi.getName();
+			imp.setRoi(cropRoi);
+			ImagePlus cropped = imp.crop(stackMode);
+			cropped.setTitle(name);
+			cropImps[i] = cropped;
+		}
+		return cropImps;
+	}
 
 	int getColumnCount(ImagePlus imp, int measurements) {
 		ImageStatistics stats = imp.getStatistics(measurements);

--- a/src/main/java/ij/process/ImageProcessor.java
+++ b/src/main/java/ij/process/ImageProcessor.java
@@ -2140,6 +2140,22 @@ public abstract class ImageProcessor implements Cloneable {
 	/** Returns a new processor containing an image
 		that corresponds to the current ROI. */
 	public abstract ImageProcessor crop();
+	
+	/** Returns an array of cropped ImageProcessor according to the provided list of rois. 
+	 * @see #crop
+	*/
+	public ImageProcessor[] crop(Roi[] rois) {
+		int nRois = rois.length; 
+		ImageProcessor[] cropIps = new ImageProcessor[nRois];
+		
+		for (int i=0; i<nRois; i++) {
+			Roi cropRoi = rois[i];
+			this.setRoi(cropRoi);
+			ImageProcessor cropped = this.crop();
+			cropIps[i] = cropped;
+		}
+		return cropIps;
+	}
 
 	/** Sets pixels less than or equal to level to 0 and all other
 		pixels to 255. Only works with 8-bit and 16-bit images. */

--- a/src/main/resources/macros/RoiMenuTool.txt
+++ b/src/main/resources/macros/RoiMenuTool.txt
@@ -120,4 +120,10 @@
 		outDir = "";
 	
 	RoiManager.multiCrop(mode, output, outDir, extension);
+	if (call("ij.plugin.frame.Recorder.scriptMode")=="true")
+        call("ij.plugin.frame.Recorder.recordString", "rm.multiCrop(imp,'" + mode + "');\n");
+    else
+        call("ij.plugin.frame.Recorder.recordString", "RoiManager.multiCrop('" + mode + "','" + output + "','" + outDir + "','" + extension + "');\n");
+	
+	
  }

--- a/src/main/resources/macros/RoiMenuTool.txt
+++ b/src/main/resources/macros/RoiMenuTool.txt
@@ -1,6 +1,6 @@
   var rCmds = newMenu("ROI Menu Tool", 
       newArray("Set Default Group...", "Set Default Stroke Width...", "-", 
-      "Set Group of Selected ROIs", "Select Group", "-", "Properties..." , "Install Keypad Shortcuts") );
+      "Set Group of Selected ROIs", "Select Group", "Multi-crop", "-", "Properties..." , "Install Keypad Shortcuts") );
 
   macro "ROI Menu Tool - C037T0d15RT8c12oTfc12i" {
       cmd = getArgument();
@@ -10,8 +10,10 @@
           setDefaultRoiStrokeWidth();
       else if (cmd=="Set Group of Selected ROIs")
           setRoiGroup();       
-       else if (cmd=="Select Group")
+      else if (cmd=="Select Group")
           selectRoiGroup();
+      else if (cmd=="Multi-crop")
+          multiCrop_Dialog();
       else if (cmd=="Properties...")
           properties();
       else if (cmd=="Install Keypad Shortcuts")
@@ -86,3 +88,36 @@
      else
         call("ij.plugin.frame.Recorder.recordString", "RoiManager.selectGroup("+group+");\n");
   }
+
+
+ function multiCrop_Dialog(){
+ 	image = getImageID();
+ 	n = nSlices();
+	
+	Dialog.create("ROI multiCrop");
+	
+	if (n>1) Dialog.addChoice("Crop stack to a", newArray("slice", "stack"));
+	
+	Dialog.addChoice("Choose output", newArray("show", "save", "both"));
+	Dialog.addChoice("Output image format (if saving)", newArray("tif", "jpg", "gif", "raw", "bmp", "png"));	
+	Dialog.show();
+	
+	// RECOVER CHOICES
+	// 1) crop mode for stacks
+	if (n>1)
+		mode = Dialog.getChoice();
+	else
+		mode = "slice";
+	
+	// 2) output type and 3) image file extension for saving
+	output    = Dialog.getChoice(); 
+	extension = Dialog.getChoice();
+	
+	// Ask output directory where to save images
+	if ((output=="save") || (output=="both"))
+		outDir = getDirectory("Select output directory");
+	else
+		outDir = "";
+	
+	RoiManager.multiCrop(mode, output, outDir, extension);
+ }


### PR DESCRIPTION
Hello Wayne,
This PR propose new `crop(Roi[] rois)` method signatures for the ImagePlus and ImageProcessor class.
As well as a `roiManager.multiCrop` method and its equivalent macro function, which can be called via the Roi Menu > multi-crop entry.

The new signatures allow to crop an image provided a list of rois (or using the rois in the current RoiManager instance).
For the ImagePlus and ImageProcessor, a list of the cropped images is returned.

This save some boilerplate coding when one wants to crop image-regions delimited by rois, which is something that users often want to do but dont really have the skills to code it with a for-loop...
Especially for the macro language, the function allows to display or save the cropped images or both.

__Something that needs polishing is the recording of the command__ when using the RoiMenu > multiCrop

1) when saving the images, the path is recorded with single backslash, which raise an issue when the command is then called.
I dont know how to force the double slashing programmatically.

2) Also the string arguments are recorded with single quotes, which is no problem for e.g. jython, but for Javascript or Java, I'm afraid it might be an issue.

Here is the macro function signature
`RoiManager.multiCrop('slice','save','C:\Users\Laurent Thomas\Downloads\crop\','jpg');`
1st argument: "slice", "stack" or a range "10-20" like the options for the imp.crop
2nd argument: "show", "save" or "both"
3rd : output directory, empty if show
4rth : extension for the cropped images when saving