### PR TITLE
Fix ContrastEnhancer.stretchHistogram(ImagePlus imp, double saturated) with stacks

### DIFF
--- a/src/main/java/ij/plugin/ContrastEnhancer.java
+++ b/src/main/java/ij/plugin/ContrastEnhancer.java
@@ -275,7 +275,7 @@ public class ContrastEnhancer implements PlugIn, Measurements {
 			//int[] mask = imp.getMask();
 			//Rectangle rect = imp.get
 			ImageStack stack = imp.getStack();
-			for (int i=1; i<=stackSize; i++) {
+			for (int i=1; i<=stack.getSize(); i++) {
 				IJ.showProgress(i, stackSize);
 				ImageProcessor ip = stack.getProcessor(i);
 				if (histogram==null)


### PR DESCRIPTION
With setProcessStack(true), the command was not actually processing the stack.
I believe because the for loop was using the field `stackSize` which default to 0, instead of the stack size for the ImagePlus passed to the function.

Test jython script to test with an opened stack
```python
#@ImagePlus imp
from ij.plugin import ContrastEnhancer

enhancer = ContrastEnhancer()
#enhancer.setProcessStack(True) # Uncomment this line and nothing happens
enhancer.stretchHistogram(imp,50) 
imp.updateAndDraw()
```