### PR TITLE
Opener.getFileType as static method

### DIFF
--- a/src/main/java/ij/io/Opener.java
+++ b/src/main/java/ij/io/Opener.java
@@ -1201,14 +1201,14 @@ public class Opener {
 		if (!((new File(path)).exists()))
 			return("not found");
 		else
-			return Opener.types[(new Opener()).getFileType(path)];
+			return Opener.types[getFileType(path)];
 	}
 	
 	/**
 	Attempts to determine the image file type by looking for
 	'magic numbers' and the file name extension.
 	 */
-	public int getFileType(String path) {
+	public static int getFileType(String path) {
 		if (openUsingPlugins && !path.endsWith(".txt") &&  !path.endsWith(".java"))
 			return UNKNOWN;
 		File file = new File(path);

--- a/src/main/java/ij/plugin/NextImageOpener.java
+++ b/src/main/java/ij/plugin/NextImageOpener.java
@@ -136,8 +136,7 @@ public class NextImageOpener implements PlugIn {
 			if (names[candidate].startsWith(".") || nextFile.isDirectory())
 				canOpen = false;
 			if (canOpen) {
-				Opener o = new Opener();
-				int type = o.getFileType(nextPath);
+				int type = Opener.getFileType(nextPath);
 				if (type==Opener.UNKNOWN || type==Opener.JAVA_OR_TEXT
 				||  type==Opener.ROI ||  type==Opener.TEXT)
 					canOpen = false;


### PR DESCRIPTION
Hi there,
I think most of the content in the Opener class could actually be static since the constructor is empty.
That's quite some change though, so maybe starting with just the method `getFileType` is sufficient for the moment.

It would be more consistent with `getFileFormat` which is also static, and would allow access from the macro-language using the `call("class.method");`. 
