### PR TITLE
StackTools - Add c,z,t position setter with hyperstacks

### DIFF
--- a/src/main/java/ij/plugin/Animator.java
+++ b/src/main/java/ij/plugin/Animator.java
@@ -359,14 +359,29 @@ public class Animator implements PlugIn {
 
 	void setSlice() {
         GenericDialog gd = new GenericDialog("Set Slice");
-        gd.addNumericField("Slice Number (1-"+nSlices+"):", slice, 0);
+        if (imp.isHyperStack()) {
+        	gd.addNumericField("C", 1);
+        	gd.addNumericField("Z", 1);
+        	gd.addNumericField("T", 1);
+        }
+        else
+        	gd.addNumericField("Slice Number (1-"+nSlices+"):", slice, 0);
+        
         gd.showDialog();
+        
         if (!gd.wasCanceled()) {
-        	int n = (int)gd.getNextNumber();
-        	if (imp.isDisplayedHyperStack())
-        		imp.setPosition(n);
-        	else
+        	
+        	if (imp.isDisplayedHyperStack()) {
+        		int c = (int) gd.getNextNumber();
+	    		int z = (int) gd.getNextNumber();
+	    		int t = (int) gd.getNextNumber();
+        		imp.setPosition(c, z, t);
+        	}
+        		
+        	else {
+            	int n = (int)gd.getNextNumber();
         		imp.setSlice(n);
+        	}
         }
 	}
 


### PR DESCRIPTION
The Stack Tools menu > Set Slice... will display a form for c,z,t position instead of a single integer selection when the active image is a hyperstack.
⚠**However the macro-recording does not work as expected with hyperstacks** it always records `setSlice(1);`, 
I don't know at which level the recording is happening...


![image](https://user-images.githubusercontent.com/26764505/122183585-a8a39180-ce8b-11eb-874a-76ff658dfc95.png)

As a side note, what's the best repo for such contributions ? the ImageJ1 repo description states to file PR on ImageJA, but the Readme in ImageJA advises ImageJ1 😅