### PR TITLE
Describe how to contribute to ImageJ1.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ See the [ImageJA page](https://imagej.net/libs/imageja) for details.
 
 Because much of the content in this repository is generated automatically, depending on the type of change you want to make your edit should go in one of three places:
 
-* Source file content changes (e.g. bug fixes) should go to the [imagej1 repository](https://github.com/imagej/imagej1).
+* Source file content changes (e.g. bug fixes) should go to the [imagej1 repository](https://github.com/imagej/imagej1). To submit changes in the ImageJ1 repository, see [Contributing#ImageJ](https://imagej.net/contribute/#imagej) on the Wiki.
 * Source file *location* changes (e.g. moving a file to the correct package) go in the [ij1-builds repository](https://github.com/imagej/ij1-builds).
 * Changes to the build structure (e.g. `pom.xml` updates) can be done directly in this repository.


### PR DESCRIPTION
The procedure to contribute to ImageJ1.x is poorly described.

The README is very brief: it simply says that changes should go to the [imagej1 repository](https://github.com/imagej/imagej1). On the other hand, the ImageJ1 repository, indicates:

> To develop this code, use https://github.com/imagej/ImageJA. 

yielding an infinite loop.

The actual way to contribute to ImageJ1.x is described on [this section](https://imagej.net/contribute/#imagej) of the wiki.